### PR TITLE
ensure dates are in UTC

### DIFF
--- a/helpers/formatDate.js
+++ b/helpers/formatDate.js
@@ -17,7 +17,7 @@ module.exports = function( dust ) {
     var date = dust.helpers.tap( params.date, chunk, context );
     var format = dust.helpers.tap( params.format, chunk, context );
     // simply use moment to turn the passed date into the passed ofrmat
-    return chunk.write( moment( date ).format( format ) );
+    return chunk.write( moment.utc( date ).format( format ) );
   };
 
 };

--- a/helpers/formatDate.js
+++ b/helpers/formatDate.js
@@ -16,7 +16,7 @@ module.exports = function( dust ) {
     params = params || {};
     var date = dust.helpers.tap( params.date, chunk, context );
     var format = dust.helpers.tap( params.format, chunk, context );
-    // simply use moment to turn the passed date into the passed ofrmat
+    // simply use moment to turn the passed date into the passed format
     return chunk.write( moment.utc( date ).format( format ) );
   };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "the-wall-templater-dustjs",
 	"description": "The Wall compatible template handler",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"homepage": "https://github.com/holidayextras/the-wall-templater-dustjs",
 	"author": {
 		"name": "Shortbreaks",


### PR DESCRIPTION
#### What are the links to relevant tickets?
https://hxshortbreaks.atlassian.net/browse/WEB-6819

#### What does this PR do?
Ensures that dates passed between the-wall and the client are in UTC, so that going over the BST / DST period does not mess up times on ATG (and others).

This also ensures that we account for client-side timezone offsets when parsing the show time from CLNDR (on ATG).

#### What functional/unit tests does this PR have?
None

#### How should a developer review this?
If pulling down to test, you'll need to run this alongside the following PRs:
* https://github.com/holidayextras/the-wall/pull/92
* https://github.com/holidayextras/theatreBlueprint/pull/142

You can change your local machine timezone, and then attempt to run ATG. When selecting a show date (for lion king, for example) at any time in the year, it should be 7:30pm for evening shows.

#### Any background context you want to provide?
#### Screenshots (if appropriate)
---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [x] I've updated documentation with any changes to procedures.
- [x] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.

#### Reviewer 1 @t1gr0u
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!

#### Reviewer 2 @robhuzzey
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [ ] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!