### PR TITLE
WEB-8344: merge central section to left and right

### DIFF
--- a/helpers/filterSeats.js
+++ b/helpers/filterSeats.js
@@ -342,7 +342,7 @@ module.exports = function(dust) {
       });
 
       _.forEach(targetedSectionIndexes, function(centralSectionIndex) {
-        centralSectionIndex = parseInt(centralSectionIndex);
+        centralSectionIndex = parseInt(centralSectionIndex, 10);
         var mergedSection = getLeftCentreRightMergedSection(
           reply[centralSectionIndex - 1],
           reply[centralSectionIndex],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-wall-templater-dustjs",
   "description": "The Wall compatible template handler",
-  "version": "3.3.2", 
+  "version": "3.3.3", 
   "homepage": "https://github.com/holidayextras/the-wall-templater-dustjs",
   "author": {
     "name": "Shortbreaks",


### PR DESCRIPTION
#### What are the links to relevant tickets?
https://hxshortbreaks.atlassian.net/browse/WEB-8344
#### What does this PR do?
If a section is split into left centre right, then the filterSeats helper will pick the cheapest seat from the centre first. If there is not centre seat for a colour then it will pick the cheapest seat from the left or the right section. At the end of the process left right and centre will be merged into a unique single section.
#### What functional/unit tests does this PR have?
Filter seats - Dust helpers
#### Is there anything a developer should be aware of when reviewing this?
You can check this working for the show Sunny Afternoon
#### Screenshots (if appropriate)
![screen shot 2016-07-15 at 13 39 52](https://cloud.githubusercontent.com/assets/12378473/16874543/c2443514-4a91-11e6-9af3-1ff259fc2673.png)
![screen shot 2016-07-15 at 13 40 20](https://cloud.githubusercontent.com/assets/12378473/16874544/c24a2dca-4a91-11e6-82e7-7e05f0d20087.png)

---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [ ] I've updated documentation with any changes to procedures.
- [x] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.

#### Reviewer 1 @jamescogley
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!

#### Reviewer 2 @owennicol
- [x] I agree with the assumptions made in the quality checklist.
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!