### PR TITLE
FP-2258 - Adding getRoomDescription Helper for use with offsite hotels

### DIFF
--- a/helpers/getRoomDescription.js
+++ b/helpers/getRoomDescription.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var _ = require('lodash');
+var roomTypes = require( '../lib/roomTypes' );
+
+module.exports = function(dust) {
+
+  /*
+  * @description Extend dustjs with a helper which retrieves hotel room descriptions
+  * for offsite hotels - function adds occupancyType, adults, children to create the
+  * roomType key e.g. 'TWIN11' this is then used to return the roomDescription
+  * @param {string} occupancyType, room code i.e. 'SGL', 'TWIN'
+  * @param {string} adults, number of adults i.e. 1,2
+  * @param {string} children, number of children i.e. 1,2
+  * @example {@_getRoomDescription occupancyType="TWIN" adults="1" children="1" /} output TWIN11
+  */
+
+  dust.helpers._getRoomDescription = function(chunk, context, bodies, params) {
+    var roomCode = params.occupancytype + params.adults + params.children;
+    return chunk.write(_.get(roomTypes, [roomCode, 'roomDescription'], 'Description Not Found'));
+  };
+};

--- a/lib/roomTypes.js
+++ b/lib/roomTypes.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 // Duplicate file (the-wall->blueprints->themeBlueprint->src->configs->roomTypes.js)
 module.exports = {
   'SGL10': { 'occupancyType': 'SGL', 'roomDescription': 'Single room (1 adult)', 'adults': 1, 'children': 0, 'roomShortDesc': 'Single room' },
@@ -23,4 +23,4 @@ module.exports = {
   'FM0642': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (4 adults and 2 children)', 'adults': 4, 'children': 2, 'roomShortDesc': 'Family room' },
   'FM0651': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (5 adults and 1 child)', 'adults': 5, 'children': 1, 'roomShortDesc': 'Family room' },
   'FM0660': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (6 adults)', 'adults': 6, 'children': 0, 'roomShortDesc': 'Family room' }
-}
+};

--- a/lib/roomTypes.js
+++ b/lib/roomTypes.js
@@ -1,0 +1,26 @@
+'use strict'
+// Duplicate file (the-wall->blueprints->themeBlueprint->src->configs->roomTypes.js)
+module.exports = {
+  'SGL10': { 'occupancyType': 'SGL', 'roomDescription': 'Single room (1 adult)', 'adults': 1, 'children': 0, 'roomShortDesc': 'Single room' },
+  'TWIN11': { 'occupancyType': 'TWIN', 'roomDescription': 'Twin room (1 adult and 1 child)', 'adults': 1, 'children': 1, 'roomShortDesc': 'Twin room' },
+  'TWIN20': { 'occupancyType': 'TWIN', 'roomDescription': 'Twin room (2 adults)', 'adults': 2, 'children': 0, 'roomShortDesc': 'Twin room' },
+  'DBL20': { 'occupancyType': 'DBL', 'roomDescription': 'Double room (2 adults)', 'adults': 2, 'children': 0, 'roomShortDesc': 'Double room' },
+  'TPL12': { 'occupancyType': 'TPL', 'roomDescription': 'Triple room (1 adult and 2 children)', 'adults': 1, 'children': 2, 'roomShortDesc': 'Triple room' },
+  'TPL21': { 'occupancyType': 'TPL', 'roomDescription': 'Triple room (2 adults and 1 child)', 'adults': 2, 'children': 1, 'roomShortDesc': 'Triple room' },
+  'TPL30': { 'occupancyType': 'TPL', 'roomDescription': 'Triple room (3 adults)', 'adults': 3, 'children': 0, 'roomShortDesc': 'Triple room' },
+  'QUAD13': { 'occupancyType': 'QUAD', 'roomDescription': 'Family room (1 adult and 3 children)', 'adults': 1, 'children': 3, 'roomShortDesc': 'Family room' },
+  'QUAD22': { 'occupancyType': 'QUAD', 'roomDescription': 'Family room (2 adults and 2 children)', 'adults': 2, 'children': 2, 'roomShortDesc': 'Family room' },
+  'QUAD31': { 'occupancyType': 'QUAD', 'roomDescription': 'Family room (3 adults and 1 child)', 'adults': 3, 'children': 1, 'roomShortDesc': 'Family room' },
+  'QUAD40': { 'occupancyType': 'QUAD', 'roomDescription': 'Family room (4 adults)', 'adults': 4, 'children': 0, 'roomShortDesc': 'Family room' },
+  'FM0532': { 'occupancyType': 'FM05', 'roomDescription': 'Family room (3 adults and 2 children)', 'adults': 3, 'children': 2, 'roomShortDesc': 'Family room' },
+  'FM0523': { 'occupancyType': 'FM05', 'roomDescription': 'Family room (2 adults and 3 children)', 'adults': 2, 'children': 3, 'roomShortDesc': 'Family room' },
+  'FM0514': { 'occupancyType': 'FM05', 'roomDescription': 'Family room (1 adult and 4 children)', 'adults': 1, 'children': 4, 'roomShortDesc': 'Family room' },
+  'FM0541': { 'occupancyType': 'FM05', 'roomDescription': 'Family room (4 adults and 1 child)', 'adults': 4, 'children': 1, 'roomShortDesc': 'Family room' },
+  'FM0550': { 'occupancyType': 'FM05', 'roomDescription': 'Family room (5 adults)', 'adults': 5, 'children': 0, 'roomShortDesc': 'Family room' },
+  'FM0624': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (2 adults and 4 children)', 'adults': 2, 'children': 4, 'roomShortDesc': 'Family room' },
+  'FM0615': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (1 adult and 5 children)', 'adults': 1, 'children': 5, 'roomShortDesc': 'Family room' },
+  'FM0633': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (3 adults and 3 children)', 'adults': 3, 'children': 3, 'roomShortDesc': 'Family room' },
+  'FM0642': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (4 adults and 2 children)', 'adults': 4, 'children': 2, 'roomShortDesc': 'Family room' },
+  'FM0651': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (5 adults and 1 child)', 'adults': 5, 'children': 1, 'roomShortDesc': 'Family room' },
+  'FM0660': { 'occupancyType': 'FM06', 'roomDescription': 'Family room (6 adults)', 'adults': 6, 'children': 0, 'roomShortDesc': 'Family room' }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-wall-templater-dustjs",
   "description": "The Wall compatible template handler",
-  "version": "3.4.0", 
+  "version": "3.4.1", 
   "homepage": "https://github.com/holidayextras/the-wall-templater-dustjs",
   "author": {
     "name": "Shortbreaks",


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
The ticket was to add the room type to the Harry Potter confirmation page for offsite hotels.

However room types were not showing for any offsite hotels on the confirmation pages, so it makes sense to amend all offsite hotels to have this information.

Room details should now show for both the confirmation page and the confirmation email when booking with an offsite hotel.

#### What tests does this PR have?
None

#### How can this be tested?
I would recommend testing all sites confirmation pages and emails. With onsite and offsite booking.

All confirmation pages & confirmation emails received should be working as intended.

- For offsite hotels the confirmation pages and emails should read in the following format:
<img width="588" alt="screen shot 2017-09-28 at 22 27 01" src="https://user-images.githubusercontent.com/32061182/31010505-fbde8276-a502-11e7-9cf3-525fd39a979f.png">

- For onsite hotels (Where rooms were already listed), there should be no change.
<img width="587" alt="screen shot 2017-09-28 at 22 33 09" src="https://user-images.githubusercontent.com/32061182/31010547-22702d72-a503-11e7-8ff1-23fb04ff2c78.png">


#### Any tech debt?
I have needed to duplicate the roomTypes.js into the the-wall-templater-dustjs repo, although not ideal, It is the best solution I have found. I am open to any other suggestions I may not be aware of for this.

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
https://giphy.com/gifs/hoppip-cat-drawing-11dR2hEgtN5KoM

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
