### PR TITLE
NB-1361: Created a HASH helper

### DIFF
--- a/helpers/hash.js
+++ b/helpers/hash.js
@@ -1,0 +1,17 @@
+'use strict';
+var crypto = require('crypto');
+module.exports = function(dust) {
+  /*
+  * @description Extend dustjs with a hash helper (using SHA1)
+  * @param {string} value the value you want hashed
+  * @example {@_hash value="foobar" /} output 8843d7f92416211de9ebb963ff4ce28125932878
+  */
+
+  dust.helpers._hash = function(chunk, context, bodies, params) {
+    params = params || {};
+    var shasum = crypto.createHash('sha1');
+    shasum.update(params.value);
+    return chunk.write(shasum.digest('hex'));
+  };
+
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "the-wall-templater-dustjs",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -732,7 +732,6 @@
     },
     "deployment-helpers": {
       "version": "git+ssh://git@github.com/holidayextras/deployment-helpers.git#edfb3741cb9a082c22c5efac3a957f159b7b4a46",
-      "integrity": "sha1-Px3z++cPamFpc4eDhWMY+1ohSfo=",
       "dev": true,
       "requires": {
         "@octokit/rest": "14.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-wall-templater-dustjs",
   "description": "The Wall compatible template handler",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "homepage": "https://github.com/holidayextras/the-wall-templater-dustjs",
   "author": {
     "name": "Shortbreaks",


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Adds a HASH helper so we can encode values - this is for a solution here: https://hxshortbreaks.atlassian.net/browse/NB-1361 where I want to pass the email address in the URL to HXML but cannot expose customer data. Hashing the value solves this.

#### What tests does this PR have?
N/A... I view this as legacy code.

#### How can this be tested?
You can see this working on my machine.

#### Any tech debt?
Yes... it's DUST

#### Screenshots / Screencast
N/A

#### What gif best describes how you feel about this work?
nope.

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---